### PR TITLE
Housekeeping.

### DIFF
--- a/.github/workflows/emacs-matrix-tests.yml
+++ b/.github/workflows/emacs-matrix-tests.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       matrix:
         emacs-version:
-          - '27.2'
           - '28.2'
           - '29.4'
+          - '30.2'
           - 'release-snapshot'
           # - 'snapshot'
     steps:

--- a/README.org
+++ b/README.org
@@ -5,8 +5,11 @@
 # Some parsers require this option to export footnotes.
 #+options: f:t
 
-# MELPA Badges
-=loopy-dash=: [[https://melpa.org/#/loopy-dash][file:https://melpa.org/packages/loopy-dash-badge.svg]]
+# Badges
+[[https://elpa.nongnu.org/nongnu/loopy-dash.html][file:https://elpa.nongnu.org/nongnu/loopy-dash.svg]]
+[[https://elpa.nongnu.org/nongnu-devel/loopy-dash.html][file:https://elpa.nongnu.org/nongnu-devel/loopy-dash.svg]]
+[[https://melpa.org/#/loopy-dash][file:https://melpa.org/packages/loopy-dash-badge.svg]]
+[[https://stable.melpa.org/#/loopy-dash][file:https://stable.melpa.org/packages/loopy-dash-badge.svg]]
 
 -----
 

--- a/loopy-dash.el
+++ b/loopy-dash.el
@@ -4,9 +4,9 @@
 
 ;; Author: Earl Hyatt
 ;; Created: February 2021
-;; URL: https://github.com/okamsn/loopy
+;; URL: https://github.com/okamsn/loopy-dash
 ;; Version: 0.13.0
-;; Package-Requires: ((emacs "25.1") (loopy "0.13.0") (dash "2.19"))
+;; Package-Requires: ((emacs "28.1") (loopy "0.13.0") (dash "2.20"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
 


### PR DESCRIPTION
- In `README.org`:
  - Update badges at top of file to point towards current page for `loopy-dash`,
    now that is it located separately from `loopy`.

- In `loopy-dash.el`:
  - Update Emacs version required to 28.1, the same as for Loopy.
  - Update Dash version required to 2.20.

- In `emacs-matrix-tests.yml`:
  - Stop testing Emacs 27.2.
  - List Emacs 30.2 separately.