### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/emacs-matrix-tests.yml
+++ b/.github/workflows/emacs-matrix-tests.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - master
+permissions: {}
 jobs:
   test:
     name: 'Install and Test'
@@ -21,7 +22,9 @@ jobs:
           - 'release-snapshot'
           # - 'snapshot'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - uses: purcell/setup-emacs@master
       with:
         version: ${{ matrix.emacs-version }}
@@ -45,4 +48,13 @@ jobs:
       run: emacs -batch -l tests/install-script.el
     - name: Dash tests
       run: emacs -batch -l tests/load-path.el -l ert -l tests/dash-tests.el -f ert-run-tests-batch-and-exit
+    - name: Byte Compilation test
+      run: emacs -batch --eval='(package-activate-all)' -f batch-byte-compile ~/.emacs.d/elpa/loopy-dash*/*.el
+    - name: Native Compilation test
+      run: |
+        if [[ t = $(emacs -batch --eval="(prin1 (and (fboundp 'batch-native-compile) (funcall 'native-comp-available-p)))")  ]]; then
+            emacs -batch --eval='(package-activate-all)' -f batch-native-compile ~/.emacs.d/elpa/loopy-dash*/*.el
+        else
+           echo Not running due to not having native compilation installed.
+        fi
     - run: echo "🍏 This job's status is ${{ job.status }}."


### PR DESCRIPTION
- Deny all permissions.
- Set `persist-credentials` to `false` for `actions/checkout`.
- Use `v6` of `actions/checkout`.
- Add byte compilation and native compilation (if installed) tests.